### PR TITLE
更新战机AreaGuard逻辑

### DIFF
--- a/DynamicPatcher/Projects/Extension/Kraotos/MyExtension/FighterAreaGuard.cs
+++ b/DynamicPatcher/Projects/Extension/Kraotos/MyExtension/FighterAreaGuard.cs
@@ -1,0 +1,287 @@
+﻿using DynamicPatcher;
+using Extension.Utilities;
+using PatcherYRpp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Extension.Ext
+{
+    [Serializable]
+    public class FighterAreaGuardData
+    {
+        public bool AreaGuard;
+        public int GuardRange;
+        public bool AutoFire;
+        public int MaxAmmo;
+   
+        public FighterAreaGuardData(bool areaGuard)
+        {
+            AreaGuard = areaGuard;
+            GuardRange = 5;
+            AutoFire = false;
+            MaxAmmo = 1;
+        }
+
+    }
+
+
+
+    public partial class TechnoExt
+    {
+        private bool isAreaProtecting = false;
+
+        private CoordStruct areaProtectTo;
+
+        private static List<CoordStruct> areaGuardCoords = new List<CoordStruct>()
+        {
+            new CoordStruct(-300,-300,0),
+            new CoordStruct(-300,0,0),
+            new CoordStruct(0,0,0),
+            new CoordStruct(300,0,0),
+            new CoordStruct(300,300,0),
+            new CoordStruct(0,300,0),
+        };
+
+        private int currentAreaProtectedIndex = 0;
+
+        private bool isAreaGuardReloading = false;
+
+        private int areaGuardTargetCheckRof = 20;
+
+
+        public unsafe void TechnoClass_Update_Fighter_Area_Guard()
+        {
+            FighterAreaGuardData data = Type.FighterAreaGuardData;
+
+        
+            if (!data.AreaGuard)
+            {
+                return;
+            }
+
+            var mission = OwnerObject.Convert<MissionClass>();
+
+            if (mission.Ref.CurrentMission == Mission.Move)
+            {
+                isAreaProtecting = false;
+                isAreaGuardReloading = false;
+                return;
+            }
+
+            if (OwnerObject.CastToFoot(out Pointer<FootClass> pfoot))
+            {
+                if (!isAreaProtecting)
+                {
+                    if (mission.Ref.CurrentMission == Mission.Area_Guard)
+                    {
+                        isAreaProtecting = true;
+
+                        CoordStruct dest = pfoot.Ref.Locomotor.Destination();
+                        areaProtectTo = dest;
+                    }
+                }
+
+
+                if (isAreaProtecting)
+                {
+                    //没弹药的情况下返回机场
+                    if(OwnerObject.Ref.Ammo==0 && !isAreaGuardReloading)
+                    {
+                        OwnerObject.Ref.SetTarget(default);
+                        OwnerObject.Ref.SetDestination(default(Pointer<CellClass>), false);
+                        mission.Ref.ForceMission(Mission.Stop);
+                        isAreaGuardReloading = true;
+                        return;
+                    }
+
+                    //填弹完毕后继续巡航
+                    if (isAreaGuardReloading)
+                    {
+                        if(OwnerObject.Ref.Ammo >= data.MaxAmmo)
+                        {
+                            isAreaGuardReloading = false;
+                            mission.Ref.ForceMission(Mission.Area_Guard);
+                        }
+                        else
+                        {
+                            if (mission.Ref.CurrentMission != Mission.Sleep && mission.Ref.CurrentMission != Mission.Enter)
+                            {
+                                if (mission.Ref.CurrentMission == Mission.Guard)
+                                {
+                                    mission.Ref.ForceMission(Mission.Sleep);
+                                }
+                                else
+                                {
+                                    mission.Ref.ForceMission(Mission.Enter);
+                                }
+                                return;
+                            }
+                        }
+                    }
+                   
+
+                    if (mission.Ref.CurrentMission == Mission.Move)
+                    {
+                        isAreaProtecting = false;
+                        return;
+                    }
+                    else if (mission.Ref.CurrentMission == Mission.Attack)
+                    {
+                        return;
+                    }
+                    else if (mission.Ref.CurrentMission == Mission.Enter)
+                    {
+                        if(isAreaGuardReloading)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            mission.Ref.ForceMission(Mission.Stop);
+                        }
+                    }else if(mission.Ref.CurrentMission == Mission.Sleep)
+                    {
+                        if (isAreaGuardReloading)
+                        {
+                            return;
+                        }
+                    }
+
+
+                    if (areaProtectTo != null)
+                    {
+                        var dest = areaProtectTo;
+
+                        var house = OwnerObject.Ref.Owner;
+
+                        if(data.AutoFire)
+                        {
+                            if (areaProtectTo.DistanceFrom(OwnerObject.Ref.Base.Base.GetCoords()) <= 2000)
+                            {
+                                if (areaGuardTargetCheckRof-- <= 0)
+                                {
+                                    areaGuardTargetCheckRof = 20;
+
+                                    var target = Finder.FineOneTechno(house, x =>
+                                    {
+                                        var coords = x.Ref.Base.Base.GetCoords();
+                                        var height = x.Ref.Base.GetHeight();
+                                        var type = x.Ref.Base.Base.WhatAmI();
+
+                                        if (x.Ref.Base.InLimbo)
+                                        {
+                                            return false;
+                                        }
+
+                                        var bounsRange = 0;
+                                        if (x.Ref.Base.GetHeight() > 10)
+                                        {
+                                            bounsRange = data.GuardRange;
+                                        }
+
+                                        //if (coords.Z > dest.Z)
+                                        //{
+                                        //    if (coords.Z - location.Z > 300)
+                                        //    {
+                                        //        //空中目标奖励距离
+                                        //        bounsRange = 1024;
+                                        //    }
+                                        //}
+
+                                        if ((coords - new CoordStruct(0, 0, height)).DistanceFrom(dest) <= (data.GuardRange * 256 + bounsRange) && type != AbstractType.Building)
+                                        {
+                                            return true;
+                                        }
+                                        return false;
+                                    }, FindRange.Enermy);
+
+                                    if (target.TryGet(out TechnoExt targetTechno))
+                                    {
+                                        OwnerObject.Ref.SetTarget(targetTechno.OwnerObject.Convert<AbstractClass>());
+                                        mission.Ref.ForceMission(Mission.Stop);
+                                        mission.Ref.ForceMission(Mission.Attack);
+                                        return;
+                                    }
+                                }
+
+                            }
+                        }
+                       
+
+
+                        if (areaProtectTo.DistanceFrom(OwnerObject.Ref.Base.Base.GetCoords()) <= 2000)
+                        {
+                            if (currentAreaProtectedIndex > areaGuardCoords.Count() - 1)
+                            {
+                                currentAreaProtectedIndex = 0;
+                            }
+                            dest += areaGuardCoords[currentAreaProtectedIndex];
+                            currentAreaProtectedIndex++;
+                        }
+
+                        pfoot.Ref.Locomotor.Move_To(dest);
+                        var cell = MapClass.Coord2Cell(dest);
+                        if (MapClass.Instance.TryGetCellAt(cell, out Pointer<CellClass> pcell))
+                        {
+                            OwnerObject.Ref.SetDestination(pcell, false);
+                        }
+                    }
+                }
+            }
+
+        }
+
+    }
+
+    public partial class TechnoTypeExt
+    {
+        public FighterAreaGuardData FighterAreaGuardData;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="section"></param>
+        private void ReadFighterGuardData(INIReader reader, string section)
+        {
+            if(FighterAreaGuardData==null)
+            {
+                bool areaGuard = false;
+                if (reader.ReadNormal(section, "Fighter.AreaGuard", ref areaGuard))
+                {
+                    FighterAreaGuardData = new FighterAreaGuardData(areaGuard);
+
+                    if (areaGuard)
+                    {
+                        int guardRange = 5;
+                        if (reader.ReadNormal(section, "Fighter.GuardRange", ref guardRange))
+                        {
+                            FighterAreaGuardData.GuardRange = guardRange;
+                        }
+                        bool autoFire = false;
+                        if (reader.ReadNormal(section, "Fighter.AutoFire", ref autoFire))
+                        {
+                            FighterAreaGuardData.AutoFire = autoFire;
+                        }
+
+                        int maxAmmo = 1;
+                        if (reader.ReadNormal(section, "Ammo", ref maxAmmo))
+                        {
+                            FighterAreaGuardData.MaxAmmo = maxAmmo;
+                        }
+                    }
+                }
+                else
+                {
+                    FighterAreaGuardData = new FighterAreaGuardData(areaGuard);
+                }
+
+            }
+      
+        }
+    }
+
+}

--- a/DynamicPatcher/Projects/Extension/MyExtension/MyTechnoExt.cs
+++ b/DynamicPatcher/Projects/Extension/MyExtension/MyTechnoExt.cs
@@ -110,6 +110,7 @@ namespace Extension.Ext
                 TechnoClass_Update_SpawnSupport();
 
                 TechnoClass_Update_CustomWeapon();
+                TechnoClass_Update_Fighter_Area_Guard();
             }
             // 死亡还会执行的，坠落，沉没等
             TechnoClass_Update_AttachEffect();
@@ -439,6 +440,7 @@ namespace Extension.Ext
             ReadSpawnSupport(reader, section, artReader, artSection);
             ReadTrail(reader, section, artReader, artSection);
             ReadVirtualUnit(reader, section);
+            ReadFighterGuardData(reader, section);
         }
 
         [LoadAction]

--- a/DynamicPatcher/Projects/Extension/Utilities/Finder.cs
+++ b/DynamicPatcher/Projects/Extension/Utilities/Finder.cs
@@ -1,0 +1,102 @@
+﻿using Extension.Ext;
+using Extension.Utilities;
+using PatcherYRpp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Extension.Utilities
+{
+    public class Finder
+    {
+        public static List<ExtensionReference<TechnoExt>> FindTechno(Pointer<HouseClass> pHouse, Func<Pointer<TechnoClass>, bool> expression, FindRange findRange)
+        {
+            ref DynamicVectorClass<Pointer<TechnoClass>> technos = ref TechnoClass.Array;
+            List<ExtensionReference<TechnoExt>> targets = new List<ExtensionReference<TechnoExt>>();
+            for (int i = technos.Count - 1; i >= 0; i--)
+            {
+                Pointer<TechnoClass> pTechno = technos.Get(i);
+         
+                if(IsValidTechno(pTechno,pHouse,expression,findRange))
+                {
+                    ExtensionReference<TechnoExt> tref = default;
+                    tref.Set(TechnoExt.ExtMap.Find(pTechno));
+                    targets.Add(tref);
+                }
+            }
+            return targets;
+        }
+
+        public static ExtensionReference<TechnoExt> FineOneTechno(Pointer<HouseClass> pHouse, Func<Pointer<TechnoClass>, bool> expression, FindRange findRange)
+        {
+            ref DynamicVectorClass<Pointer<TechnoClass>> technos = ref TechnoClass.Array;
+            ExtensionReference<TechnoExt> tref = default;
+
+            for (int i = technos.Count - 1; i >= 0; i--)
+            {
+                Pointer<TechnoClass> pTechno = technos.Get(i);
+
+                if (IsValidTechno(pTechno, pHouse, expression, findRange))
+                {
+                    tref.Set(TechnoExt.ExtMap.Find(pTechno));
+                    return tref;
+                }
+            }
+            return tref;
+        }
+
+        private static bool IsValidTechno(Pointer<TechnoClass> pTechno,Pointer<HouseClass> pHouse, Func<Pointer<TechnoClass>, bool> expression, FindRange findRange)
+        {
+            var houseIndex = pHouse.Ref.ArrayIndex;
+
+            if (pTechno.IsNull)
+                return false;
+            if (pTechno.Ref.Owner.IsNull)
+                return false;
+
+            switch (findRange)
+            {
+                case FindRange.All:
+                    {
+                        break;
+                    }
+                case FindRange.Owner:
+                    {
+                        if (pTechno.Ref.Owner.Ref.ArrayIndex != houseIndex)
+                            return false;
+                        break;
+                    }
+                case FindRange.Allies:
+                    {
+                        if (pTechno.Ref.Owner.Ref.ArrayIndex != houseIndex && !pHouse.Ref.IsAlliedWith(pTechno.Ref.Owner.Ref.ArrayIndex))
+                            return false;
+                        break;
+                    }
+                case FindRange.Enermy:
+                    {
+                        if (pTechno.Ref.Owner.Ref.ArrayIndex == houseIndex || pHouse.Ref.IsAlliedWith(pTechno.Ref.Owner.Ref.ArrayIndex) || !pTechno.Ref.Base.IsAlive)
+                            return false;
+                        break;
+                    }
+                default:
+                    break;
+            }
+
+            return expression(pTechno);
+
+        }
+    }
+
+
+
+
+    public enum FindRange
+    {
+        All,
+        Owner,
+        Allies,
+        Enermy
+    }
+}


### PR DESCRIPTION
战机AreaGuard https://www.bilibili.com/video/BV1Aa41187CH   
1.到指定的区域巡逻
2.巡逻区域有敌方目标会主动发动攻击
3.没有弹药后会回到机场填弹
4.装填完毕后回到指定区域巡逻
5.移动指令可以取消巡逻的效果
6.中途使用攻击指令，完成攻击后回到巡逻
已在DP下测试，未在Kratos下测试，理论上兼容

使用方式
[AircraftType]
Fighter.AreaGuard=yes ;是否可以执行Ctrl+Alt的区域防守命令
Fighter.GuardRange=10   ;区域防守的范围
Fighter.AutoFire=yes  ;是否对进入范围的目标进行攻击，如果为否，则只在空中盘旋待命，建议战斗机为yes轰炸机类为no